### PR TITLE
add check for 2-beat measures

### DIFF
--- a/choraleTools/mnum_fixer.py
+++ b/choraleTools/mnum_fixer.py
@@ -47,8 +47,29 @@ def runOne(c, cName):
             perfect = True if short == 0 else False
             pickup = True if not perfect and short > (barQl / 2) else False
             truncated = True if not perfect and short < (barQl / 2) else False
+            half = True if not perfect and short == (barQl / 2) else False
 
-            if perfect:
+            if half and priorMeasureWasIncomplete==False:
+                priorMeasureWasIncomplete = True
+                priorMeasureDuration = mQl
+                priorMeasure = m
+                m.number = mn - measureNumberShift
+                partNumSuffix.append((mn - measureNumberShift, ms))
+            elif half and priorMeasureWasIncomplete and priorMeasureDuration == short:
+                priorMeasureWasIncomplete = False
+                m.paddingLeft = short
+                priorMeasure = m
+                priorMeasureDuration = mQl
+                measureNumberShift += 1
+                if ms is None:
+                    ms = 'a'
+                else:
+                    ms = ms + 'a'
+                m.number = mn - measureNumberShift
+                m.numberSuffix = ms
+                partNumSuffix.append((mn - measureNumberShift, ms))
+                
+            elif perfect:
                 priorMeasureWasIncomplete = False
                 priorMeasureDuration = mQl
                 priorMeasure = m


### PR DESCRIPTION
Maintain correct measure numbering when system breaks occur at half-measures
Possible examples include:
  bwv382 (R49), bwv42.7 (R91), bwv42.7 (R132), bwv433 (R137), bwv248.33-3 (R139), 
  bwv409 (R141), bwv339 (R144), bwv384 (R149), bwv154.8 (R152), bwv410 (R172),
  bwv424 (R193), bwv283 (R198), bwv284 (R200), bwv275 (R210), bwv329 (R212), 
  bwv383 (R214), bwv374 (R227), bwv296 (R231), bwv411 (R246), bwv42.7 (R259), 
  bwv380 (R299), bwv283 (R307), bwv339 (R318), bwv70.11 (R348), bwv422 (R357)